### PR TITLE
adds reboot support to chocolatey

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,5 +14,13 @@ class chocolatey (
     provider  => powershell,
     subscribe => File['chocolatey script'],
     creates   => 'c:\\ProgramData\\chocolatey\\',
+    tries     => '2',
   }
+
+  reboot { 'chocolatey reboot':
+    subscribe => Exec['install chocolatey'],
+    apply     => finished,
+  }
+
+
 }


### PR DESCRIPTION
we need to restart to make sure chocolately is loaded properly, this
does a reboot at the end of the run by default, assuming nothing else
needs chocolately yet. our profile::windows::baseline module will
restart the machine before hand if it sees this pending reboot.

Kind of messy about state, but also convenient.
